### PR TITLE
feat(scout): use SCOUT_GITHUB_TOKEN env var

### DIFF
--- a/extensions/specialized-subagents/lib/clients/github.ts
+++ b/extensions/specialized-subagents/lib/clients/github.ts
@@ -252,9 +252,9 @@ export class GitHubClient {
   private token: string;
 
   constructor() {
-    const token = process.env.GITHUB_TOKEN;
+    const token = process.env.SCOUT_GITHUB_TOKEN;
     if (!token) {
-      throw new Error("GITHUB_TOKEN environment variable is not set.");
+      throw new Error("SCOUT_GITHUB_TOKEN environment variable is not set.");
     }
     this.token = token;
   }
@@ -289,7 +289,9 @@ export class GitHubClient {
         throw new Error(`Rate limit exceeded or access denied: ${text}`);
       }
       if (response.status === 401) {
-        throw new Error("Authentication failed. Check GITHUB_TOKEN validity.");
+        throw new Error(
+          "Authentication failed. Check SCOUT_GITHUB_TOKEN validity.",
+        );
       }
       throw new Error(`GitHub API error (${response.status}): ${text}`);
     }


### PR DESCRIPTION
Use dedicated SCOUT_GITHUB_TOKEN environment variable for the scout extension's GitHub client instead of GITHUB_TOKEN.