### PR TITLE
feat(scout): add DownloadGist and UploadGist tools

### DIFF
--- a/GIST_TOOLS_SUMMARY.md
+++ b/GIST_TOOLS_SUMMARY.md
@@ -1,0 +1,165 @@
+# Gist Tools for Scout Extension
+
+This document describes the two new tools added to the Scout extension for managing GitHub Gists.
+
+## Overview
+
+Two new tools have been added to enable downloading and uploading GitHub Gists:
+
+1. **download_gist** - Downloads/clones a GitHub Gist to a temporary directory
+2. **upload_gist** - Updates a GitHub Gist by committing and pushing changes
+
+## Tools
+
+### download_gist
+
+**Purpose:** Clone a GitHub Gist to a temporary directory for local manipulation.
+
+**Parameters:**
+- `gistId` (string, required): GitHub Gist ID or full Gist URL
+  - Examples: `"abc123def456"` or `"https://gist.github.com/username/abc123def456"`
+
+**Returns:**
+- Markdown document with:
+  - Gist ID
+  - Local directory path (temporary directory in system temp folder)
+  - Gist URL
+  - List of files in the cloned directory
+
+**Example Usage:**
+```json
+{
+  "gistId": "abc123def456"
+}
+```
+
+or
+
+```json
+{
+  "gistId": "https://gist.github.com/username/abc123def456"
+}
+```
+
+**Notes:**
+- Uses `git clone` to download the Gist
+- Creates a temporary directory with prefix `gist-{id}-`
+- Directory persists after tool execution (not automatically cleaned up)
+- Requires git to be installed and available in PATH
+
+---
+
+### upload_gist
+
+**Purpose:** Update a GitHub Gist by committing and pushing changes from a local directory.
+
+**Parameters:**
+- `directory` (string, required): Path to the directory containing the Gist files
+  - Must be a git repository cloned from a Gist
+  - Can be relative or absolute path
+- `commitMessage` (string, optional): Commit message for the update
+  - Default: `"Update gist files"`
+
+**Returns:**
+- Markdown document with:
+  - Gist ID
+  - Directory path
+  - Gist URL
+  - Commit details (hash, author, date, message)
+  - Push output
+
+**Example Usage:**
+```json
+{
+  "directory": "/tmp/gist-abc123def456-xyz",
+  "commitMessage": "Updated configuration files"
+}
+```
+
+**Validation:**
+- Checks that the directory exists and is a directory
+- Validates that it's a git repository
+- Verifies the remote URL is a GitHub Gist URL
+- Detects if there are changes to commit (returns early if no changes)
+
+**Notes:**
+- All changes in the directory are staged with `git add -A`
+- Pushes to the current branch (auto-detected, typically `master` for Gists)
+- **Important:** Gists are flat repositories - they cannot contain subdirectories
+- Requires git to be configured with GitHub authentication (HTTPS token or SSH)
+
+## Implementation Details
+
+### Files Created/Modified
+
+1. **Created:**
+   - `extensions/specialized-subagents/subagents/scout/tools/download-gist.ts`
+   - `extensions/specialized-subagents/subagents/scout/tools/upload-gist.ts`
+
+2. **Modified:**
+   - `extensions/specialized-subagents/subagents/scout/tools/index.ts` - Added exports
+   - `extensions/specialized-subagents/subagents/scout/tool-formatter.ts` - Added formatting for new tools
+   - `extensions/specialized-subagents/subagents/scout/system-prompt.ts` - Updated system prompt to document new tools
+
+### Key Features
+
+**download_gist:**
+- Extracts Gist ID from either raw ID or full URL
+- Creates unique temporary directory for each download
+- Uses native git commands for cloning
+- Lists files after successful clone
+
+**upload_gist:**
+- Validates directory is a cloned Gist repository
+- Auto-detects current git branch
+- Checks for changes before committing
+- Provides detailed commit information
+- Handles errors gracefully with descriptive messages
+
+### Error Handling
+
+Both tools provide clear error messages for common issues:
+- Invalid Gist ID/URL format
+- Directory doesn't exist (upload_gist)
+- Not a git repository (upload_gist)
+- Not a Gist repository (upload_gist)
+- Git command failures
+- Network/authentication issues
+
+## Workflow Example
+
+Here's a typical workflow using both tools together:
+
+1. **Download a Gist:**
+   ```json
+   {
+     "gistId": "https://gist.github.com/username/abc123def456"
+   }
+   ```
+   Returns: `/tmp/gist-abc123def456-xyz123/`
+
+2. **Make changes to files in the directory** (using other tools or manual edits)
+
+3. **Upload the changes:**
+   ```json
+   {
+     "directory": "/tmp/gist-abc123def456-xyz123/",
+     "commitMessage": "Fixed typo in README"
+   }
+   ```
+
+## Limitations
+
+1. **Flat Structure:** Gists cannot contain subdirectories - all files must be in the root directory
+2. **Authentication:** Requires git to be configured with GitHub authentication for upload
+3. **Manual Cleanup:** Downloaded temporary directories are not automatically cleaned up
+4. **Single Remote:** Assumes standard Gist setup with origin remote
+
+## Future Enhancements
+
+Possible improvements for future versions:
+- Auto-cleanup of temporary directories after a configurable timeout
+- Support for creating new Gists (not just updating existing ones)
+- Better handling of large Gists with many files
+- Progress indicators for long-running operations
+- Support for Gist privacy settings (public/private)

--- a/extensions/specialized-subagents/subagents/scout/system-prompt.ts
+++ b/extensions/specialized-subagents/subagents/scout/system-prompt.ts
@@ -17,6 +17,10 @@ export const SCOUT_SYSTEM_PROMPT = `You are Scout, a research assistant speciali
 - **github_issue**: Fetch an issue or pull request with comments. Works for both issues and PRs.
 - **list_user_repos**: List repositories for a GitHub user. Supports filtering by language, name prefix, and sorting.
 
+### Gist Tools
+- **download_gist**: Clone a GitHub Gist to a temporary directory. Provide Gist ID or full URL. Returns the path to the directory.
+- **upload_gist**: Update a GitHub Gist by committing and pushing changes from a local directory. The directory must be a cloned Gist repository. Note: Gists are flat repositories and cannot contain subdirectories.
+
 ## Behavior
 
 Based on your input, decide what to do:

--- a/extensions/specialized-subagents/subagents/scout/tool-formatter.ts
+++ b/extensions/specialized-subagents/subagents/scout/tool-formatter.ts
@@ -139,6 +139,38 @@ export function formatScoutToolCall(
       return { label: "List Repos" };
     }
 
+    case "download_gist": {
+      const gistId = args.gistId as string | undefined;
+      if (gistId) {
+        // Extract just the ID if it's a URL
+        let id = gistId;
+        try {
+          const parsed = new URL(gistId);
+          const parts = parsed.pathname.split("/").filter(Boolean);
+          if (parts.length > 0) {
+            id = parts[parts.length - 1];
+          }
+        } catch {
+          // Not a URL, use as-is
+        }
+        return { label: "Download Gist", detail: id };
+      }
+      return { label: "Download Gist" };
+    }
+
+    case "upload_gist": {
+      const directory = args.directory as string | undefined;
+      const commitMessage = args.commitMessage as string | undefined;
+      if (directory) {
+        let detail = directory;
+        if (commitMessage) {
+          detail += ` - "${commitMessage}"`;
+        }
+        return { label: "Upload Gist", detail };
+      }
+      return { label: "Upload Gist" };
+    }
+
     default:
       return { label: toolName };
   }

--- a/extensions/specialized-subagents/subagents/scout/tools/download-gist.ts
+++ b/extensions/specialized-subagents/subagents/scout/tools/download-gist.ts
@@ -1,0 +1,125 @@
+/**
+ * Download Gist tool - clones a GitHub Gist to a temporary directory.
+ */
+
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { execSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const parameters = Type.Object({
+  gistId: Type.String({
+    description:
+      "GitHub Gist ID or full Gist URL (e.g., 'abc123def456' or 'https://gist.github.com/username/abc123def456')",
+  }),
+});
+
+/**
+ * Extract Gist ID from input string.
+ * Handles both raw IDs and full URLs.
+ */
+function extractGistId(input: string): string {
+  // If it's a URL, extract the ID
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    try {
+      const url = new URL(input);
+      if (!url.hostname.includes("gist.github.com")) {
+        throw new Error(`Not a GitHub Gist URL: ${input}`);
+      }
+      const parts = url.pathname.split("/").filter(Boolean);
+      // URL format: https://gist.github.com/username/gistId
+      if (parts.length < 2) {
+        throw new Error(`Invalid Gist URL: ${input}`);
+      }
+      return parts[parts.length - 1]; // Last part is the Gist ID
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("Gist")) {
+        throw error;
+      }
+      throw new Error(`Invalid Gist URL: ${input}`);
+    }
+  }
+
+  // Otherwise, treat as raw Gist ID
+  // Validate format (alphanumeric)
+  if (!/^[a-zA-Z0-9]+$/.test(input)) {
+    throw new Error(`Invalid Gist ID format: ${input}`);
+  }
+
+  return input;
+}
+
+export const downloadGistTool: ToolDefinition<typeof parameters> = {
+  name: "download_gist",
+  label: "Download Gist",
+  description: `Clone a GitHub Gist to a temporary directory.
+
+Returns the path to the temporary directory containing the cloned Gist.
+
+Usage:
+- Provide Gist ID: gistId="abc123def456"
+- Provide full URL: gistId="https://gist.github.com/username/abc123def456"
+
+Note: The temporary directory is created in the system's temp folder and will need to be cleaned up manually if desired.`,
+
+  parameters,
+
+  async execute(
+    _toolCallId: string,
+    args: { gistId: string },
+    _onUpdate: unknown,
+    _ctx: unknown,
+    signal?: AbortSignal,
+  ) {
+    const { gistId: gistInput } = args;
+    const gistId = extractGistId(gistInput);
+
+    // Create temporary directory
+    const tempDir = mkdtempSync(join(tmpdir(), `gist-${gistId}-`));
+
+    try {
+      // Clone the Gist using git
+      const gistUrl = `https://gist.github.com/${gistId}.git`;
+
+      // Check if signal is already aborted
+      if (signal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+
+      // Clone the repository
+      execSync(`git clone "${gistUrl}" "${tempDir}"`, {
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+
+      // List files in the cloned directory
+      const files = execSync(`ls -la "${tempDir}"`, {
+        stdio: "pipe",
+        encoding: "utf-8",
+      }).toString();
+
+      let markdown = `# Gist Downloaded\n\n`;
+      markdown += `**Gist ID:** ${gistId}\n`;
+      markdown += `**Directory:** \`${tempDir}\`\n`;
+      markdown += `**URL:** https://gist.github.com/${gistId}\n\n`;
+      markdown += `## Files\n\n`;
+      markdown += `\`\`\`\n${files}\`\`\`\n`;
+
+      return {
+        content: [{ type: "text" as const, text: markdown }],
+        details: {
+          gistId,
+          directory: tempDir,
+          url: `https://gist.github.com/${gistId}`,
+        },
+      };
+    } catch (error) {
+      // If cloning failed, we should report the error
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to clone Gist ${gistId}: ${errorMessage}`);
+    }
+  },
+};

--- a/extensions/specialized-subagents/subagents/scout/tools/index.ts
+++ b/extensions/specialized-subagents/subagents/scout/tools/index.ts
@@ -4,11 +4,13 @@
 
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { webFetchTool } from "../../../lib/tools";
+import { downloadGistTool } from "./download-gist";
 import { githubCommitsTool } from "./github-commits";
 import { githubContentTool } from "./github-content";
 import { githubIssueTool } from "./github-issue";
 import { githubSearchTool } from "./github-search";
 import { listUserReposTool } from "./list-user-repos";
+import { uploadGistTool } from "./upload-gist";
 import { webSearchTool } from "./web-search";
 
 /** Create scout tools array */
@@ -21,15 +23,19 @@ export function createScoutTools(): ToolDefinition[] {
     githubCommitsTool,
     githubIssueTool,
     listUserReposTool,
+    downloadGistTool,
+    uploadGistTool,
   ] as unknown as ToolDefinition[];
 }
 
 export {
+  downloadGistTool,
   githubCommitsTool,
   githubContentTool,
   githubIssueTool,
   githubSearchTool,
   listUserReposTool,
+  uploadGistTool,
   webFetchTool,
   webSearchTool,
 };

--- a/extensions/specialized-subagents/subagents/scout/tools/upload-gist.ts
+++ b/extensions/specialized-subagents/subagents/scout/tools/upload-gist.ts
@@ -1,0 +1,239 @@
+/**
+ * Upload Gist tool - updates a GitHub Gist by pushing changes from a directory.
+ */
+
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { execSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const parameters = Type.Object({
+  directory: Type.String({
+    description:
+      "Path to the directory containing the files to upload/update in the Gist",
+  }),
+  commitMessage: Type.Optional(
+    Type.String({
+      description:
+        "Commit message for the update (defaults to 'Update gist files')",
+    }),
+  ),
+});
+
+/**
+ * Check if a directory is a git repository with a remote.
+ */
+function validateGitRepo(directory: string): {
+  isGist: boolean;
+  remoteUrl?: string;
+  gistId?: string;
+} {
+  try {
+    // Check if it's a git repository
+    const gitDir = execSync(`git -C "${directory}" rev-parse --git-dir`, {
+      stdio: "pipe",
+      encoding: "utf-8",
+    })
+      .toString()
+      .trim();
+
+    if (!gitDir) {
+      return { isGist: false };
+    }
+
+    // Get the remote URL
+    const remoteUrl = execSync(`git -C "${directory}" remote get-url origin`, {
+      stdio: "pipe",
+      encoding: "utf-8",
+    })
+      .toString()
+      .trim();
+
+    // Check if it's a Gist URL
+    // Gist URLs are like: https://gist.github.com/<gistId>.git
+    const gistMatch = remoteUrl.match(
+      /gist\.github\.com[/:]([a-zA-Z0-9]+)\.git/,
+    );
+    if (!gistMatch) {
+      return { isGist: false, remoteUrl };
+    }
+
+    return {
+      isGist: true,
+      remoteUrl,
+      gistId: gistMatch[1],
+    };
+  } catch {
+    return { isGist: false };
+  }
+}
+
+export const uploadGistTool: ToolDefinition<typeof parameters> = {
+  name: "upload_gist",
+  label: "Upload Gist",
+  description: `Update a GitHub Gist by pushing changes from a local directory.
+
+The directory must be a git repository that was cloned from a Gist (e.g., using download_gist).
+All changes in the directory will be committed and pushed to the Gist.
+
+Note: Gists are flat repositories - they cannot contain subdirectories. All files must be in the root of the directory.
+
+Usage:
+- Provide directory path: directory="/tmp/gist-abc123def456-xyz"
+- Optional commit message: commitMessage="Updated configuration"
+
+Requires: Git configured with GitHub authentication (HTTPS or SSH)`,
+
+  parameters,
+
+  async execute(
+    _toolCallId: string,
+    args: { directory: string; commitMessage?: string },
+    _onUpdate: unknown,
+    _ctx: unknown,
+    signal?: AbortSignal,
+  ) {
+    const { directory: dirInput, commitMessage = "Update gist files" } = args;
+
+    // Resolve to absolute path
+    const directory = resolve(dirInput);
+
+    // Check if directory exists
+    if (!existsSync(directory)) {
+      throw new Error(`Directory does not exist: ${directory}`);
+    }
+
+    // Check if it's a directory
+    if (!statSync(directory).isDirectory()) {
+      throw new Error(`Not a directory: ${directory}`);
+    }
+
+    // Validate it's a Gist repository
+    const repoInfo = validateGitRepo(directory);
+    if (!repoInfo.isGist) {
+      throw new Error(
+        `Directory is not a cloned Gist repository: ${directory}` +
+          (repoInfo.remoteUrl
+            ? `\nRemote URL: ${repoInfo.remoteUrl}`
+            : "\nNo git remote found."),
+      );
+    }
+
+    const { gistId, remoteUrl } = repoInfo;
+
+    // Check if signal is already aborted
+    if (signal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
+    try {
+      // Add all changes
+      execSync(`git -C "${directory}" add -A`, {
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+
+      // Check if there are changes to commit
+      let hasChanges = false;
+      try {
+        execSync(`git -C "${directory}" diff --cached --quiet`, {
+          stdio: "pipe",
+          encoding: "utf-8",
+        });
+      } catch {
+        // Non-zero exit means there are changes
+        hasChanges = true;
+      }
+
+      if (!hasChanges) {
+        let markdown = `# No Changes to Upload\n\n`;
+        markdown += `**Gist ID:** ${gistId}\n`;
+        markdown += `**Directory:** \`${directory}\`\n`;
+        markdown += `**URL:** https://gist.github.com/${gistId}\n\n`;
+        markdown += `_No changes detected in the directory._\n`;
+
+        return {
+          content: [{ type: "text" as const, text: markdown }],
+          details: {
+            gistId,
+            directory,
+            url: `https://gist.github.com/${gistId}`,
+            hasChanges: false,
+          },
+        };
+      }
+
+      // Commit changes
+      execSync(`git -C "${directory}" commit -m "${commitMessage}"`, {
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+
+      // Get the current branch name
+      const currentBranch = execSync(
+        `git -C "${directory}" rev-parse --abbrev-ref HEAD`,
+        {
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      )
+        .toString()
+        .trim();
+
+      // Push to remote
+      const pushOutput = execSync(
+        `git -C "${directory}" push origin ${currentBranch}`,
+        {
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      ).toString();
+
+      // Get the latest commit info
+      const commitInfo = execSync(
+        `git -C "${directory}" log -1 --pretty=format:"%H%n%an%n%ae%n%ai%n%s"`,
+        {
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      ).toString();
+
+      const [commitHash, authorName, authorEmail, commitDate, commitSubject] =
+        commitInfo.split("\n");
+
+      let markdown = `# Gist Updated\n\n`;
+      markdown += `**Gist ID:** ${gistId}\n`;
+      markdown += `**Directory:** \`${directory}\`\n`;
+      markdown += `**URL:** https://gist.github.com/${gistId}\n\n`;
+      markdown += `## Commit Details\n\n`;
+      markdown += `- **Hash:** \`${commitHash?.substring(0, 7)}\`\n`;
+      markdown += `- **Author:** ${authorName} <${authorEmail}>\n`;
+      markdown += `- **Date:** ${commitDate}\n`;
+      markdown += `- **Message:** ${commitSubject}\n\n`;
+
+      if (pushOutput.trim()) {
+        markdown += `## Push Output\n\n`;
+        markdown += `\`\`\`\n${pushOutput}\`\`\`\n`;
+      }
+
+      return {
+        content: [{ type: "text" as const, text: markdown }],
+        details: {
+          gistId,
+          directory,
+          url: `https://gist.github.com/${gistId}`,
+          hasChanges: true,
+          commitHash: commitHash?.substring(0, 7),
+          commitMessage: commitSubject,
+        },
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to update Gist ${gistId}: ${errorMessage}`,
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Adds two new tools to the Scout extension for managing GitHub Gists:

- **download_gist**: Clone a GitHub Gist to a temporary directory
- **upload_gist**: Update a GitHub Gist by committing and pushing changes

## Features

### DownloadGist
- Accepts Gist ID or full URL (e.g., `abc123` or `https://gist.github.com/user/abc123`)
- Clones the Gist to a temporary directory using `git clone`
- Returns the path to the cloned directory
- Lists all files in the Gist

### UploadGist
- Takes a directory path and optional commit message
- Validates the directory is a cloned Gist repository
- Auto-detects the current git branch (not hardcoded)
- Checks for changes before committing
- Commits and pushes changes to the Gist
- Returns detailed commit information

## Implementation Details

Both tools include:
- ✅ Flexible input handling (URLs and raw IDs)
- ✅ Comprehensive validation and error handling
- ✅ Markdown-formatted output
- ✅ Integration with Scout's tool formatting
- ✅ Updated system prompt documentation

## Files Changed

**Created:**
- `extensions/specialized-subagents/subagents/scout/tools/download-gist.ts`
- `extensions/specialized-subagents/subagents/scout/tools/upload-gist.ts`
- `GIST_TOOLS_SUMMARY.md` (detailed documentation)

**Modified:**
- `extensions/specialized-subagents/subagents/scout/tools/index.ts`
- `extensions/specialized-subagents/subagents/scout/tool-formatter.ts`
- `extensions/specialized-subagents/subagents/scout/system-prompt.ts`

## Usage Example

```javascript
// Download a Gist
const result = await scout({
  prompt: "Download gist abc123def456",
});
// Returns: /tmp/gist-abc123def456-xyz/

// Make changes to files...

// Upload changes
const uploadResult = await scout({
  prompt: "Upload changes in /tmp/gist-abc123def456-xyz/ with message 'Fixed typo'",
});
```

## Notes

- Gists are flat repositories and cannot contain subdirectories (documented in tool descriptions)
- Download creates temporary directories that are not automatically cleaned up
- Upload requires git to be configured with GitHub authentication
- Both tools use native git commands for reliability

## Documentation

See `GIST_TOOLS_SUMMARY.md` for comprehensive documentation including:
- Detailed parameter descriptions
- Error handling information
- Workflow examples
- Known limitations
- Future enhancement ideas