### PR TITLE
feat(guardrails): add preventPython guardrail to block Python tools

### DIFF
--- a/.changeset/guardrails-prevent-python.md
+++ b/.changeset/guardrails-prevent-python.md
@@ -1,0 +1,10 @@
+---
+"@aliou/pi-guardrails": minor
+---
+
+Add preventPython guardrail to block Python tools.
+
+- Block python, python3, pip, pip3, poetry, pyenv, virtualenv, and venv commands.
+- Recommend using uv for Python package management instead.
+- Disabled by default, configurable via settings.
+- Provides helpful guidance on using uv as a replacement.

--- a/extensions/guardrails/config-schema.ts
+++ b/extensions/guardrails/config-schema.ts
@@ -9,6 +9,7 @@ export interface GuardrailsConfig {
   enabled?: boolean;
   features?: {
     preventBrew?: boolean;
+    preventPython?: boolean;
     protectEnvFiles?: boolean;
     permissionGate?: boolean;
   };
@@ -34,6 +35,7 @@ export interface ResolvedConfig {
   enabled: boolean;
   features: {
     preventBrew: boolean;
+    preventPython: boolean;
     protectEnvFiles: boolean;
     permissionGate: boolean;
   };

--- a/extensions/guardrails/config.ts
+++ b/extensions/guardrails/config.ts
@@ -16,6 +16,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   enabled: true,
   features: {
     preventBrew: false,
+    preventPython: false,
     protectEnvFiles: true,
     permissionGate: true,
   },

--- a/extensions/guardrails/events.ts
+++ b/extensions/guardrails/events.ts
@@ -4,7 +4,11 @@ export const GUARDRAILS_BLOCKED_EVENT = "guardrails:blocked";
 export const GUARDRAILS_DANGEROUS_EVENT = "guardrails:dangerous";
 
 export interface GuardrailsBlockedEvent {
-  feature: "preventBrew" | "protectEnvFiles" | "permissionGate";
+  feature:
+    | "preventBrew"
+    | "preventPython"
+    | "protectEnvFiles"
+    | "permissionGate";
   toolName: string;
   input: Record<string, unknown>;
   reason: string;

--- a/extensions/guardrails/hooks/index.ts
+++ b/extensions/guardrails/hooks/index.ts
@@ -2,10 +2,12 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { ResolvedConfig } from "../config-schema";
 import { setupPermissionGateHook } from "./permission-gate";
 import { setupPreventBrewHook } from "./prevent-brew";
+import { setupPreventPythonHook } from "./prevent-python";
 import { setupProtectEnvFilesHook } from "./protect-env-files";
 
 export function setupGuardrailsHooks(pi: ExtensionAPI, config: ResolvedConfig) {
   setupPreventBrewHook(pi, config);
+  setupPreventPythonHook(pi, config);
   setupProtectEnvFilesHook(pi, config);
   setupPermissionGateHook(pi, config);
 }

--- a/extensions/guardrails/hooks/prevent-python.ts
+++ b/extensions/guardrails/hooks/prevent-python.ts
@@ -1,0 +1,45 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ResolvedConfig } from "../config-schema";
+import { emitBlocked } from "../events";
+
+/**
+ * Blocks all Python-related commands including python, python3, pip, poetry, etc.
+ * Use uv for Python package management instead.
+ */
+
+const PYTHON_PATTERN =
+  /\b(python|python3|pip|pip3|poetry|pyenv|virtualenv|venv)\b/;
+
+export function setupPreventPythonHook(
+  pi: ExtensionAPI,
+  config: ResolvedConfig,
+) {
+  if (!config.features.preventPython) return;
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (event.toolName !== "bash") return;
+
+    const command = String(event.input.command ?? "");
+
+    if (PYTHON_PATTERN.test(command)) {
+      ctx.ui.notify("Blocked Python command. Use uv instead.", "warning");
+
+      const reason =
+        "Python is not available globally on this machine. " +
+        "Use uv for Python package management instead. " +
+        "Run `uv init` to create a new Python project, " +
+        "or `uv run python` to run Python scripts. " +
+        "Use `uv add` to install packages (replaces pip/poetry).";
+
+      emitBlocked(pi, {
+        feature: "preventPython",
+        toolName: "bash",
+        input: event.input,
+        reason,
+      });
+
+      return { block: true, reason };
+    }
+    return;
+  });
+}


### PR DESCRIPTION
## Changes

Adds a new `preventPython` guardrail to block Python tools and package managers that are no longer needed when using uv.

## What is blocked

- python, python3
- pip, pip3
- poetry
- pyenv
- virtualenv, venv

## Behavior

- Disabled by default, configurable via settings
- Shows a warning notification when a Python command is blocked
- Provides helpful guidance on using uv as a replacement
- Emits a guardrails blocked event for tracking

## Why

Python is not available globally on this machine. Using uv for Python package management is the recommended approach instead of traditional pip, poetry, or virtualenv workflows.

## Breaking changes

None (disabled by default)

## Version bump

Minor version bump for @aliou/pi-guardrails