### PR TITLE
refactor(planning): use shared ConfigLoader

### DIFF
--- a/extensions/planning/lib/config.ts
+++ b/extensions/planning/lib/config.ts
@@ -1,57 +1,25 @@
 /**
  * Planning extension configuration
  *
- * Settings are loaded from ~/.pi/agent/extensions/planning.json
- * No local fallback - must be configured globally.
+ * Settings are loaded from ~/.pi/agent/extensions/planning.json (global only).
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
-
-const GLOBAL_CONFIG_PATH = resolve(
-  homedir(),
-  ".pi/agent/extensions/planning.json",
-);
+import { ConfigLoader } from "@aliou/pi-utils-settings";
 
 export interface PlanningConfig {
   /** Directory where archived plans are stored (should be a git repo) */
   archiveDir?: string;
 }
 
-class ConfigLoader {
-  private config: PlanningConfig | null = null;
-
-  async load(): Promise<void> {
-    this.config = await this.loadConfigFile(GLOBAL_CONFIG_PATH);
-  }
-
-  private async loadConfigFile(path: string): Promise<PlanningConfig | null> {
-    try {
-      const content = await readFile(path, "utf-8");
-      return JSON.parse(content) as PlanningConfig;
-    } catch {
-      return null;
-    }
-  }
-
-  getConfig(): PlanningConfig {
-    return this.config ?? {};
-  }
-
-  hasConfig(): boolean {
-    return this.config !== null;
-  }
-
-  async save(config: PlanningConfig): Promise<void> {
-    await mkdir(dirname(GLOBAL_CONFIG_PATH), { recursive: true });
-    await writeFile(
-      GLOBAL_CONFIG_PATH,
-      `${JSON.stringify(config, null, 2)}\n`,
-      "utf-8",
-    );
-    this.config = config;
-  }
+export interface ResolvedPlanningConfig {
+  archiveDir: string;
 }
 
-export const configLoader = new ConfigLoader();
+const DEFAULTS: ResolvedPlanningConfig = {
+  archiveDir: "",
+};
+
+export const configLoader = new ConfigLoader<
+  PlanningConfig,
+  ResolvedPlanningConfig
+>("planning", DEFAULTS, { scopes: ["global"] });

--- a/extensions/planning/package.json
+++ b/extensions/planning/package.json
@@ -6,6 +6,9 @@
       "./index.ts"
     ]
   },
+  "dependencies": {
+    "@aliou/pi-utils-settings": "0.2.0"
+  },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": ">=0.51.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   extensions/planning:
     dependencies:
+      '@aliou/pi-utils-settings':
+        specifier: 0.2.0
+        version: 0.2.0(@mariozechner/pi-coding-agent@0.51.0(ws@8.19.0)(zod@3.25.76))
       '@mariozechner/pi-coding-agent':
         specifier: '>=0.51.0'
         version: 0.51.0(ws@8.19.0)(zod@3.25.76)


### PR DESCRIPTION
Replace the planning extension's hand-rolled `ConfigLoader` class (~45 lines) with the shared `ConfigLoader` from `@aliou/pi-utils-settings`.

## Changes

- Add `@aliou/pi-utils-settings` dependency to `extensions/planning/package.json`
- Rewrite `extensions/planning/lib/config.ts` to use the shared loader
- Add `ResolvedPlanningConfig` type for resolved config with defaults

## Notes

- No call-site changes needed; `list-plans.ts` continues using `configLoader.load()` and `configLoader.getConfig()`
- Project-level config (`.pi/extensions/planning.json`) now supported as a bonus (shared loader reads both global and project)