### PR TITLE
fix(processes): remove auto-stream on process start

### DIFF
--- a/.changeset/remove-auto-stream.md
+++ b/.changeset/remove-auto-stream.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-processes": patch
+---
+
+Remove auto-stream of logs widget on process start. The log stream widget should only appear when the user explicitly runs /process:stream.

--- a/extensions/processes/commands/index.ts
+++ b/extensions/processes/commands/index.ts
@@ -48,15 +48,10 @@ function allProcessCompletions(manager: ProcessManager) {
   };
 }
 
-export interface ProcessCommands {
-  /** Start streaming logs for a process via the widget. Needs a UI context. */
-  streamProcess: (processId: string, ui: ExtensionCommandContext["ui"]) => void;
-}
-
 export function setupProcessesCommands(
   pi: ExtensionAPI,
   manager: ProcessManager,
-): ProcessCommands {
+): void {
   let streamingProcessId: string | null = null;
 
   // ── /process:list ──────────────────────────────────────────────────
@@ -304,12 +299,6 @@ export function setupProcessesCommands(
       { placement: "aboveEditor" },
     );
   }
-
-  return {
-    streamProcess: (processId: string, ui: ExtensionCommandContext["ui"]) => {
-      startStreaming(ui, manager, processId);
-    },
-  };
 }
 
 async function pickProcess(

--- a/extensions/processes/index.ts
+++ b/extensions/processes/index.ts
@@ -19,8 +19,8 @@ export default async function (pi: ExtensionAPI) {
   const manager = new ProcessManager();
 
   const { update: updateWidget } = setupProcessesHooks(pi, manager);
-  const commands = setupProcessesCommands(pi, manager);
-  setupProcessesTools(pi, manager, commands);
+  setupProcessesCommands(pi, manager);
+  setupProcessesTools(pi, manager);
   registerProcessesSettings(pi, () => {
     updateWidget();
   });

--- a/extensions/processes/tools/index.ts
+++ b/extensions/processes/tools/index.ts
@@ -57,13 +57,7 @@ const ProcessesParams = Type.Object({
 
 type ProcessesParamsType = Static<typeof ProcessesParams>;
 
-import type { ProcessCommands } from "../commands";
-
-export function setupProcessesTools(
-  pi: ExtensionAPI,
-  manager: ProcessManager,
-  commands: ProcessCommands,
-) {
+export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
   pi.registerTool<typeof ProcessesParams, ProcessesDetails>({
     name: "process",
     label: "Process",
@@ -85,17 +79,7 @@ Note: User always sees process updates in the UI. The notify flags control wheth
     parameters: ProcessesParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await executeAction(params, manager, ctx);
-      // Auto-stream logs when a process is started successfully.
-      if (
-        params.action === "start" &&
-        result.details?.success &&
-        result.details.process &&
-        ctx.hasUI
-      ) {
-        commands.streamProcess(result.details.process.id, ctx.ui);
-      }
-      return result;
+      return executeAction(params, manager, ctx);
     },
 
     renderCall(args: ProcessesParamsType, theme: Theme): Text {


### PR DESCRIPTION
Remove auto-stream of logs widget on process start. The log stream widget should only appear when the user explicitly runs /process:stream.