### PR TITLE
fix(defaults): fall back to process.cwd() when ctx.cwd is undefined in read tool

### DIFF
--- a/extensions/defaults/tools/read.ts
+++ b/extensions/defaults/tools/read.ts
@@ -25,7 +25,7 @@ export function setupReadTool(pi: ExtensionAPI): void {
       };
 
       // Resolve path relative to extension context's working directory
-      const absolutePath = resolve(ctx.cwd, path);
+      const absolutePath = resolve(ctx.cwd || cwd, path);
 
       try {
         const stat = await lstat(absolutePath);


### PR DESCRIPTION
## Summary

- Fix `TypeError: The "paths[0]" argument must be of type string. Received undefined` when using `read` with relative paths
- `ctx.cwd` can be undefined in certain extension contexts, causing `path.resolve(undefined, path)` to throw
- Falls back to the `cwd` captured at setup time (line 13) when `ctx.cwd` is unavailable

## Reproduction

1. Use any model with the defaults extension loaded
2. Ask the agent to read a file using a relative path (e.g. `read web-search.json`)
3. Tool call fails with `The "paths[0]" argument must be of type string. Received undefined`
4. Absolute paths and `~/` paths work fine

One-line fix: `resolve(ctx.cwd || cwd, path)` instead of `resolve(ctx.cwd, path)`.