### PR TITLE
Fix Windows path handling in resolve-workspace-deps.mjs

### DIFF
--- a/scripts/resolve-workspace-deps.mjs
+++ b/scripts/resolve-workspace-deps.mjs
@@ -14,8 +14,9 @@
 
 import { readdirSync, readFileSync, existsSync, mkdirSync, symlinkSync, lstatSync } from "fs";
 import { join, dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
-const ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PACKAGES_DIR = join(ROOT, "packages");
 const EXTENSIONS_DIR = join(ROOT, "extensions");
 const NODE_MODULES = join(ROOT, "node_modules");


### PR DESCRIPTION


This pull request updates the way the script determines the root directory path to improve compatibility and reliability.

Improves path resolution:
  * In `scripts/resolve-workspace-deps.mjs`, replaces the use of `new URL(import.meta.url).pathname` with `fileURLToPath(import.meta.url)` to obtain the file path in a more robust and cross-platform way.

## Original Bug
```
> pnpm install
Scope: all 19 workspace projects                                                                                                   
Lockfile is up to date, resolution step is skipped
Packages: +402
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Downloading @biomejs/cli-win32-x64@2.3.11: 17.59 MB/17.59 MB, done
Progress: resolved 402, reused 0, downloaded 402, added 402, done
node_modules/.pnpm/better-sqlite3@12.6.2/node_modules/better-sqlite3: Running install script, done in 552ms

dependencies:
+ @aliou/pi-linkup 0.7.1
+ @aliou/pi-utils-settings 0.2.0
+ @aliou/sesame 0.4.0
+ @aliou/sh 0.1.0
+ better-sqlite3 12.6.2
+ yaml 2.8.2

devDependencies:
+ @aliou/biome-plugins 0.3.0
+ @biomejs/biome 2.3.11
+ @changesets/cli 2.29.8
+ @mariozechner/pi-agent-core 0.52.9
+ @mariozechner/pi-ai 0.52.9
+ @mariozechner/pi-coding-agent 0.52.9
+ @mariozechner/pi-tui 0.52.9
+ @sinclair/typebox 0.34.47
+ @types/better-sqlite3 7.6.13
+ @types/node 22.19.7
+ tsx 4.21.0
+ typescript 5.9.3

. postinstall$ node scripts/resolve-workspace-deps.mjs
│ node:fs:1583                                                                                                                     
│   const result = binding.readdir(                                                                                                
│                          ^                                                                                                       
│ Error: ENOENT: no such file or directory, scandir 'C:\C:\Users\username\.pi\agent\git\github.com\aliou\pi-extensions\packages'      
│     at readdirSync (node:fs:1583:26)                                                                                             
│     at file:///C:/Users/username/.pi/agent/git/github.com/aliou/pi-extensions/scripts/resolve-workspace-deps.mjs:25:19              
│     at ModuleJob.run (node:internal/modules/esm/module_job:343:25)                                                               
│     at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)                                           
│     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5) {                                            
│   errno: -4058,                                                                                                                  
│   code: 'ENOENT',                                                                                                                
│   syscall: 'scandir',
│   path: 'C:\\C:\\Users\\username\\.pi\\agent\\git\\github.com\\aliou\\pi-extensions\\packages'
│ }
│ Node.js v22.21.1
└─ Failed in 74ms at C:\Users\username\.pi\agent\git\github.com\aliou\pi-extensions
 ELIFECYCLE  Command failed with exit code 1.
```

